### PR TITLE
support link unfurling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@
 - **iconUrl**: Icon to post as. (either iconEmoji or iconUrl will be used)
 - **formatter**: Custom function to format logs. (optional)
 - **level**: Level to log. (global settings will be applied if level is blank)
+- **unfurlLinks**: Whether to [unfurl links](https://api.slack.com/docs/message-attachments#unfurling) in Slack (optional)
 
 [^1]: Integration settings on slack will be applied if it's blank.

--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -17,6 +17,7 @@ var SlackWebHook = exports.SlackWebHook = winston.transports.SlackWebHook = func
   this.username = options.username || '';
   this.iconEmoji = options.iconEmoji || '';
   this.iconUrl = options.iconUrl || '';
+  this.unfurlLinks = !!options.unfurlLinks;
 
   var parsedUrl = url.parse(this.webhookUrl);
   this.host = parsedUrl.hostname;
@@ -40,7 +41,8 @@ SlackWebHook.prototype.log = function(level, msg, meta, callback) {
     channel: this.channel,
     username: this.username,
     icon_emoji: this.iconEmoji,
-    icon_url: this.iconUrl
+    icon_url: this.iconUrl,
+    unfurl_links: this.unfurlLinks
   });
 
   var req = https.request({


### PR DESCRIPTION
Adds `unfurlLink` option. See https://api.slack.com/docs/message-attachments#unfurling
