### PR TITLE
Correct content length calculation

### DIFF
--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -52,7 +52,7 @@ SlackWebHook.prototype.log = function(level, msg, meta, callback) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Content-Length': data.length
+      'Content-Length': Buffer.byteLength(data)
     }
   }, function(res) {
     var body = '';


### PR DESCRIPTION
There is a bug that occurs when you use non-ASCII characters in a log message. For example:

``` js
logger.info("Pokémon Go");
```

Slack will never display this log message.

This is because the `Content-Length` header is based on `data.length` which is the number of characters rather than the number of bytes. I have corrected this to `Buffer.byteLength(data)`.
