### PR TITLE
added meta as slack Attachment

### DIFF
--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -6,7 +6,7 @@ var url = require('url');
 
 var winston = require('winston');
 
-var SlackWebHook = exports.SlackWebHook = winston.transports.SlackWebHook = function(options) {
+var SlackWebHook = exports.SlackWebHook = winston.transports.SlackWebHook = function (options) {
   options = options || {};
   this.name = 'slackWebHook';
   this.level = options.level || 'info';
@@ -27,23 +27,39 @@ var SlackWebHook = exports.SlackWebHook = winston.transports.SlackWebHook = func
 
 util.inherits(SlackWebHook, winston.Transport);
 
-SlackWebHook.prototype.log = function(level, msg, meta, callback) {
+SlackWebHook.prototype.log = function (level, msg, meta, callback) {
   if (typeof this.formatter === 'function') {
     msg = this.formatter({
-      level  : level,
+      level: level,
       message: msg,
-      meta   : meta
+      meta: meta
     });
   }
 
-  var data = JSON.stringify({
+  var payload = {
     text: msg,
     channel: this.channel,
     username: this.username,
     icon_emoji: this.iconEmoji,
     icon_url: this.iconUrl,
-    unfurl_links: this.unfurlLinks
-  });
+    unfurl_links: this.unfurlLinks,
+  };
+
+  if (meta) {
+    var color;
+    switch (level) {
+      case 'error': color = "danger"; break;
+      case 'warn': color = "warning"; break;
+      default: color = "good";
+    }
+    payload.attachments = [{
+      fallback: JSON.stringify(meta),
+      text: JSON.stringify(meta),
+      color: color,
+    }];
+  }
+
+  var data = JSON.stringify(payload);
 
   var req = https.request({
     host: this.host,
@@ -54,12 +70,12 @@ SlackWebHook.prototype.log = function(level, msg, meta, callback) {
       'Content-Type': 'application/json',
       'Content-Length': Buffer.byteLength(data)
     }
-  }, function(res) {
+  }, function (res) {
     var body = '';
-    res.on('data', function(chunk) {
+    res.on('data', function (chunk) {
       body += chunk;
     });
-    res.on('end', function() {
+    res.on('end', function () {
       if (res.statusCode === 200) {
         callback(null, body);
       } else {

--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -45,7 +45,7 @@ SlackWebHook.prototype.log = function (level, msg, meta, callback) {
     unfurl_links: this.unfurlLinks,
   };
 
-  if (meta) {
+  if (Object.keys(meta).length > 0) {
     var color;
     switch (level) {
       case 'error': color = "danger"; break;


### PR DESCRIPTION
Use slack attachments to show “meta” informations:

https://api.slack.com/docs/message-attachments

logger.error(‘Message.’, { test: "test" });
