### PR TITLE
allow for custom name

### DIFF
--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -8,7 +8,7 @@ var winston = require('winston');
 
 var SlackWebHook = exports.SlackWebHook = winston.transports.SlackWebHook = function (options) {
   options = options || {};
-  this.name = 'slackWebHook';
+  this.name = options.name || 'slackWebHook';
   this.level = options.level || 'info';
   this.formatter = options.formatter || null;
 


### PR DESCRIPTION
Added ability to specify a custom name for the transport, otherwise you cannot set up two separate transports.  Supporting multiple transports allows for logging at different levels to multiple channels.