### PR TITLE
list attachments individually

### DIFF
--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -52,11 +52,17 @@ SlackWebHook.prototype.log = function (level, msg, meta, callback) {
       case 'warn': color = "warning"; break;
       default: color = "good";
     }
-    payload.attachments = [{
-      fallback: JSON.stringify(meta),
-      text: JSON.stringify(meta),
-      color: color,
-    }];
+    var attachments = [];
+    for (let key in meta){
+      if (meta.hasOwnProperty(key)) {
+        attachments.push({
+            fallback: util.inspect(meta[key]),
+            text: `${key}: ${util.inspect(meta[key])}`,
+            color: color,
+        })
+      }
+    }
+    payload.attachments = attachments;
   }
 
   var data = JSON.stringify(payload);


### PR DESCRIPTION
Rather than sending one attachment that combines the meta object into a single block, send an array of attachments, one for each key/value pair. 

I used util.inspect() rather than JSON.stringify, in case a meta object contains a circular reference.  (I found this to be an issue with axios' error objects).