### PR TITLE
Add rate limiting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@
 - **formatter**: Custom function to format logs. (optional)
 - **level**: Level to log. (global settings will be applied if level is blank)
 - **unfurlLinks**: Whether to [unfurl links](https://api.slack.com/docs/message-attachments#unfurling) in Slack (optional)
+- **limitPerSecond**: max messages per second (optional)
+- **limitWindowSeconds**: size of rate limit window, to allow bursting of limit (optional)
 
 [^1]: Integration settings on slack will be applied if it's blank.

--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -5,6 +5,7 @@ var https = require('https');
 var url = require('url');
 
 var winston = require('winston');
+var noop = function () { };
 
 var SlackWebHook = exports.SlackWebHook = winston.transports.SlackWebHook = function (options) {
   options = options || {};
@@ -18,16 +19,49 @@ var SlackWebHook = exports.SlackWebHook = winston.transports.SlackWebHook = func
   this.iconEmoji = options.iconEmoji || '';
   this.iconUrl = options.iconUrl || '';
   this.unfurlLinks = !!options.unfurlLinks;
+  this.limitPerSecond = options.limitPerSecond || Infinity;
+  this.limitWindowSeconds = options.limitWindowSeconds || 30;
 
   var parsedUrl = url.parse(this.webhookUrl);
   this.host = parsedUrl.hostname;
   this.port = parsedUrl.port || 443;
   this.path = parsedUrl.path;
+
+  // Everytime a Slack message is sent, limitSent is incremeneted. But it also
+  // decays over time using the update limitSent * e^(-\lambda * seconds).
+  // Lambda is chosen such that an infinite number of messages sent at the
+  // allowed rate will coverage to limitPerSecond * limitWindowSeconds.
+  // So this limit is somewhat burstable by adjusting limitWindowSeconds.
+  this.limitLambda = this.limitPerSecond * Math.log(1 / (this.limitPerSecond * this.limitWindowSeconds) + 1);
+  this.limitSent = 0;
+  this.limitLastUpdate = new Date();
+  this.limitNumDiscarded = 0;
 }
 
 util.inherits(SlackWebHook, winston.Transport);
 
-SlackWebHook.prototype.log = function (level, msg, meta, callback) {
+SlackWebHook.prototype.getLimitSentAtDate = function (date) {
+  var secondsSinceUpdate = (date - this.limitLastUpdate) / 1000;
+  var limitSentNow = this.limitSent * Math.exp(- this.limitLambda * secondsSinceUpdate);
+
+  return limitSentNow;
+};
+
+SlackWebHook.prototype.isRateLimitExceeded = function () {
+  var limitSentNow = this.getLimitSentAtDate(new Date());
+
+  return limitSentNow > this.limitPerSecond * this.limitWindowSeconds;
+};
+
+SlackWebHook.prototype.incrementLimitSent = function () {
+  var nowDate = new Date(),
+      limitSentNow = this.getLimitSentAtDate(nowDate);
+
+  this.limitSent = limitSentNow + 1;
+  this.limitLastUpdate = nowDate;
+};
+
+SlackWebHook.prototype.sendSlackLog = function (level, msg, meta, callback) {
   if (typeof this.formatter === 'function') {
     msg = this.formatter({
       level: level,
@@ -92,4 +126,19 @@ SlackWebHook.prototype.log = function (level, msg, meta, callback) {
 
   req.write(data);
   req.end();
+};
+
+SlackWebHook.prototype.log = function (level, msg, meta, callback) {
+  if (this.isRateLimitExceeded()) {
+    this.limitNumDiscarded++;
+  } else {
+    if (this.limitNumDiscarded > 0) {
+      this.sendSlackLog('warn', 'winston-slack-webhook discarded ' + this.limitNumDiscarded + ' messages', {}, noop);
+      this.limitNumDiscarded = 0;
+      this.incrementLimitSent();
+    }
+
+    this.sendSlackLog(level, msg, meta, callback);
+    this.incrementLimitSent();
+  }
 };

--- a/lib/winston-slack-webhook.js
+++ b/lib/winston-slack-webhook.js
@@ -131,6 +131,7 @@ SlackWebHook.prototype.sendSlackLog = function (level, msg, meta, callback) {
 SlackWebHook.prototype.log = function (level, msg, meta, callback) {
   if (this.isRateLimitExceeded()) {
     this.limitNumDiscarded++;
+    callback(null);
   } else {
     if (this.limitNumDiscarded > 0) {
       this.sendSlackLog('warn', 'winston-slack-webhook discarded ' + this.limitNumDiscarded + ' messages', {}, noop);


### PR DESCRIPTION
Since Slack limits messages to one per second, I have added `limitPerSecond` and `limitWindowSeconds` options to control the rate at which messages are sent. This can help prevent Slack disconnecting a webhook (say when a production machine starts logging 100 errors/second.)